### PR TITLE
fix: remove invalid lint rules

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-Wno-int-conversion"]


### PR DESCRIPTION
This PR removes invalid cargo linting rules, to allow the project to be compiled.